### PR TITLE
fix: FileNotFoundException open failed: EPERM (Operation not permitte…

### DIFF
--- a/avatar/src/main/java/cn/libery/avatar/util/AppUtil.java
+++ b/avatar/src/main/java/cn/libery/avatar/util/AppUtil.java
@@ -25,6 +25,6 @@ public class AppUtil {
     }
 
     public static String yyyyMMddHHmmss(long date) {
-        return new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss", Locale.getDefault()).format(date);
+        return new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(date);
     }
 }


### PR DESCRIPTION
…d) during saving image file to SDCard on android 11+

I found some device would throw this Exception, like Redmi K40S Android 12 and Huawei HONOR 30 pro+ Android 12.
I found a solution at here:   https://stackoverflow.com/a/68631626/5662555